### PR TITLE
fix: add NodeJS.ProcessEnv types for process.env usage

### DIFF
--- a/apps/portfolio/src/env.d.ts
+++ b/apps/portfolio/src/env.d.ts
@@ -6,3 +6,12 @@ interface ImportMetaEnv {
   readonly SANITY_API_VERSION: string;
   readonly FORMSPREE_KEY: string;
 }
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly SANITY_PROJECT_ID: string;
+    readonly SANITY_DATASET: string;
+    readonly SANITY_API_VERSION: string;
+    readonly FORMSPREE_KEY: string;
+  }
+}


### PR DESCRIPTION
## Summary

`env.d.ts` only declared `ImportMetaEnv` types, but `src/lib/sanity.ts` uses `process.env` (not `import.meta.env`) for Sanity credentials. Without a `NodeJS.ProcessEnv` augmentation, TypeScript types those values as `string | undefined`.

Adds a `NodeJS.ProcessEnv` interface alongside the existing `ImportMetaEnv` so both access patterns are properly typed.

## Test plan

- [ ] `pnpm --filter @mfranceschit/portfolio typecheck` — 0 errors